### PR TITLE
test: add overall target

### DIFF
--- a/test/TARGETS
+++ b/test/TARGETS
@@ -1,0 +1,10 @@
+{ "":
+  { "type": "install"
+  , "tainted": ["test"]
+  , "dirs":
+    [ [["./", "hello", ""], "hello"]
+    , [["./", "proto", ""], "proto"]
+    , [["./", "withExtendedPath", ""], "withExtendedPath"]
+    ]
+  }
+}

--- a/test/hello/TARGETS
+++ b/test/hello/TARGETS
@@ -1,4 +1,5 @@
-{ "":
+{ "": {"type": "install", "tainted": ["test"], "deps": ["hello"]}
+, "hello":
   { "type": ["@", "rules", "shell/test", "script"]
   , "name": ["hello"]
   , "test": ["test_hello.sh"]

--- a/test/proto/TARGETS
+++ b/test/proto/TARGETS
@@ -1,4 +1,5 @@
-{ "":
+{ "": {"type": "install", "tainted": ["test"], "deps": ["proto"]}
+, "proto":
   { "type": ["@", "rules", "shell/test", "script"]
   , "name": ["proto"]
   , "test": ["test.sh"]

--- a/test/test_hello.sh
+++ b/test/test_hello.sh
@@ -1,5 +1,0 @@
-set -e
-
-./hello | grep -i world
-./hello Universe | grep Universe
-./hello Universe | grep -i world && exit 1 || :

--- a/test/withExtendedPath/TARGETS
+++ b/test/withExtendedPath/TARGETS
@@ -1,4 +1,5 @@
-{"withExtendedPath":
+{ "": {"type": "install", "tainted": ["test"], "deps": ["withExtendedPath"]}
+, "withExtendedPath":
   { "type": ["@", "rules", "shell/test", "script"]
   , "name": ["find-in-extended-path"]
   , "test": ["test.sh"]


### PR DESCRIPTION
... acting as a test suite for all tests; in doing so, also add the usual structure that each directory has is own overall target of only the tree objects with the test results. While there, remove duplicate copy of a test script in a wrong directory.