### PR TITLE
Update non-system dependencies

### DIFF
--- a/etc/deps-rust/TARGETS.byteorder-1.5.0
+++ b/etc/deps-rust/TARGETS.byteorder-1.5.0
@@ -1,0 +1,24 @@
+{ "byteorder":
+  { "type": "export"
+  , "target": "byteorder-internal"
+  , "flexible_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  }
+, "byteorder-internal":
+  { "type": ["@", "rules", "rust", "library"]
+  , "name": ["byteorder"]
+  , "crate_root": ["src/lib.rs"]
+  , "srcs": ["src/lib.rs", "src/io.rs"]
+  , "edition": ["2021"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "deps": []
+  , "cargo_features": []
+  , "stage": ["byteorder-1.5.0"]
+  , "version": ["1", "5", "0"]
+  , "pkg_name": ["byteorder"]
+  }
+, "default": {"type": ["@", "rules", "cargo", "feature"], "name": ["default"]}
+, "i128": {"type": ["@", "rules", "cargo", "feature"], "name": ["i128"]}
+, "std": {"type": ["@", "rules", "cargo", "feature"], "name": ["std"]}
+}

--- a/etc/deps-rust/TARGETS.ppv-lite86-0.2.18
+++ b/etc/deps-rust/TARGETS.ppv-lite86-0.2.18
@@ -1,10 +1,4 @@
 { "ppv_lite86":
-  { "type": "export"
-  , "target": "ppv_lite86-internal"
-  , "flexible_config":
-    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
-  }
-, "ppv_lite86-internal":
   { "type": ["@", "rules", "rust", "library"]
   , "name": ["ppv_lite86"]
   , "crate_root": ["src/lib.rs"]
@@ -16,13 +10,13 @@
     , "src/x86_64/mod.rs"
     , "src/x86_64/sse2.rs"
     ]
-  , "edition": ["2018"]
+  , "edition": ["2021"]
   , "arguments_config":
     ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
-  , "deps": []
+  , "deps": [["@", "zerocopy", "", "zerocopy"]]
   , "cargo_features": ["simd", "std"]
-  , "stage": ["ppv-lite86-0.2.17"]
-  , "version": ["0", "2", "17"]
+  , "stage": ["ppv-lite86-0.2.18"]
+  , "version": ["0", "2", "18"]
   , "pkg_name": ["ppv-lite86"]
   }
 , "default": {"type": ["@", "rules", "cargo", "feature"], "name": ["default"]}

--- a/etc/deps-rust/TARGETS.proc-macro2-1.0.86
+++ b/etc/deps-rust/TARGETS.proc-macro2-1.0.86
@@ -1,0 +1,46 @@
+{ "proc_macro2":
+  { "type": ["@", "rules", "rust", "library"]
+  , "name": ["proc_macro2"]
+  , "crate_root": ["src/lib.rs"]
+  , "srcs":
+    [ "build.rs"
+    , "build/probe.rs"
+    , "src/parse.rs"
+    , "src/rcvec.rs"
+    , "src/location.rs"
+    , "src/fallback.rs"
+    , "src/marker.rs"
+    , "src/wrapper.rs"
+    , "src/detection.rs"
+    , "src/extra.rs"
+    , "src/lib.rs"
+    ]
+  , "edition": ["2021"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "deps": [["@", "unicode-ident", "", "unicode_ident"]]
+  , "cargo_features": ["default", "proc-macro"]
+  , "stage": ["proc-macro2-1.0.86"]
+  , "version": ["1", "0", "86"]
+  , "pkg_name": ["proc-macro2"]
+  }
+, "build_script":
+  { "type": ["@", "rules", "cargo", "build_script"]
+  , "name": ["build_script"]
+  , "crate_root": ["build.rs"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "edition": ["2021"]
+  , "stage": ["proc-macro2-1.0.86"]
+  , "deps": [["@", "unicode-ident", "", "unicode_ident"]]
+  , "cargo_features": ["default", "proc-macro"]
+  , "version": ["1", "0", "86"]
+  , "pkg_name": ["proc-macro2"]
+  }
+, "default": {"type": ["@", "rules", "cargo", "feature"], "name": ["default"]}
+, "nightly": {"type": ["@", "rules", "cargo", "feature"], "name": ["nightly"]}
+, "proc-macro":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["proc-macro"]}
+, "span-locations":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["span-locations"]}
+}

--- a/etc/deps-rust/TARGETS.quote-1.0.36
+++ b/etc/deps-rust/TARGETS.quote-1.0.36
@@ -1,0 +1,32 @@
+{ "quote":
+  { "type": "export"
+  , "target": "quote-internal"
+  , "flexible_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  }
+, "quote-internal":
+  { "type": ["@", "rules", "rust", "library"]
+  , "name": ["quote"]
+  , "crate_root": ["src/lib.rs"]
+  , "srcs":
+    [ "src/spanned.rs"
+    , "src/runtime.rs"
+    , "src/format.rs"
+    , "src/to_tokens.rs"
+    , "src/lib.rs"
+    , "src/ident_fragment.rs"
+    , "src/ext.rs"
+    ]
+  , "edition": ["2018"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "deps": [["@", "proc-macro2", "", "proc_macro2"]]
+  , "cargo_features": ["default", "proc-macro"]
+  , "stage": ["quote-1.0.36"]
+  , "version": ["1", "0", "36"]
+  , "pkg_name": ["quote"]
+  }
+, "default": {"type": ["@", "rules", "cargo", "feature"], "name": ["default"]}
+, "proc-macro":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["proc-macro"]}
+}

--- a/etc/deps-rust/TARGETS.syn-2.0.72
+++ b/etc/deps-rust/TARGETS.syn-2.0.72
@@ -1,0 +1,105 @@
+{ "syn":
+  { "type": "export"
+  , "target": "syn-internal"
+  , "flexible_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  }
+, "syn-internal":
+  { "type": ["@", "rules", "rust", "library"]
+  , "name": ["syn"]
+  , "crate_root": ["src/lib.rs"]
+  , "srcs":
+    [ "src/spanned.rs"
+    , "src/stmt.rs"
+    , "src/group.rs"
+    , "src/parse.rs"
+    , "src/parse_macro_input.rs"
+    , "src/fixup.rs"
+    , "src/lit.rs"
+    , "src/bigint.rs"
+    , "src/buffer.rs"
+    , "src/classify.rs"
+    , "src/export.rs"
+    , "src/thread.rs"
+    , "src/verbatim.rs"
+    , "src/mac.rs"
+    , "src/meta.rs"
+    , "src/print.rs"
+    , "src/item.rs"
+    , "src/derive.rs"
+    , "src/macros.rs"
+    , "src/error.rs"
+    , "src/parse_quote.rs"
+    , "src/expr.rs"
+    , "src/precedence.rs"
+    , "src/discouraged.rs"
+    , "src/punctuated.rs"
+    , "src/drops.rs"
+    , "src/lib.rs"
+    , "src/lifetime.rs"
+    , "src/op.rs"
+    , "src/generics.rs"
+    , "src/file.rs"
+    , "src/data.rs"
+    , "src/path.rs"
+    , "src/ext.rs"
+    , "src/restriction.rs"
+    , "src/lookahead.rs"
+    , "src/token.rs"
+    , "src/ident.rs"
+    , "src/span.rs"
+    , "src/ty.rs"
+    , "src/sealed.rs"
+    , "src/attr.rs"
+    , "src/whitespace.rs"
+    , "src/custom_keyword.rs"
+    , "src/tt.rs"
+    , "src/pat.rs"
+    , "src/custom_punctuation.rs"
+    , "src/gen/visit_mut.rs"
+    , "src/gen/fold.rs"
+    , "src/gen/hash.rs"
+    , "src/gen/debug.rs"
+    , "src/gen/clone.rs"
+    , "src/gen/visit.rs"
+    , "src/gen/eq.rs"
+    ]
+  , "edition": ["2021"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "deps":
+    [ ["@", "proc-macro2", "", "proc_macro2"]
+    , ["@", "quote", "", "quote"]
+    , ["@", "unicode-ident", "", "unicode_ident"]
+    ]
+  , "cargo_features":
+    [ "clone-impls"
+    , "default"
+    , "derive"
+    , "parsing"
+    , "printing"
+    , "proc-macro"
+    , "visit"
+    ]
+  , "stage": ["syn-2.0.72"]
+  , "version": ["2", "0", "72"]
+  , "pkg_name": ["syn"]
+  }
+, "clone-impls":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["clone-impls"]}
+, "default": {"type": ["@", "rules", "cargo", "feature"], "name": ["default"]}
+, "derive": {"type": ["@", "rules", "cargo", "feature"], "name": ["derive"]}
+, "extra-traits":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["extra-traits"]}
+, "fold": {"type": ["@", "rules", "cargo", "feature"], "name": ["fold"]}
+, "full": {"type": ["@", "rules", "cargo", "feature"], "name": ["full"]}
+, "parsing": {"type": ["@", "rules", "cargo", "feature"], "name": ["parsing"]}
+, "printing":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["printing"]}
+, "proc-macro":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["proc-macro"]}
+, "test": {"type": ["@", "rules", "cargo", "feature"], "name": ["test"]}
+, "visit": {"type": ["@", "rules", "cargo", "feature"], "name": ["visit"]}
+, "visit-mut":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["visit-mut"]}
+}

--- a/etc/deps-rust/TARGETS.unicode-ident-1.0.12
+++ b/etc/deps-rust/TARGETS.unicode-ident-1.0.12
@@ -1,0 +1,21 @@
+{ "unicode_ident":
+  { "type": "export"
+  , "target": "unicode_ident-internal"
+  , "flexible_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  }
+, "unicode_ident-internal":
+  { "type": ["@", "rules", "rust", "library"]
+  , "name": ["unicode_ident"]
+  , "crate_root": ["src/lib.rs"]
+  , "srcs": ["src/tables.rs", "src/lib.rs"]
+  , "edition": ["2018"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "deps": []
+  , "cargo_features": []
+  , "stage": ["unicode-ident-1.0.12"]
+  , "version": ["1", "0", "12"]
+  , "pkg_name": ["unicode-ident"]
+  }
+}

--- a/etc/deps-rust/TARGETS.zerocopy-0.6.6
+++ b/etc/deps-rust/TARGETS.zerocopy-0.6.6
@@ -1,0 +1,37 @@
+{ "zerocopy":
+  { "type": "export"
+  , "target": "zerocopy-internal"
+  , "flexible_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  }
+, "zerocopy-internal":
+  { "type": ["@", "rules", "rust", "library"]
+  , "name": ["zerocopy"]
+  , "crate_root": ["src/lib.rs"]
+  , "srcs":
+    [ "src/post_monomorphization_compile_fail_tests.rs"
+    , "src/derive_util.rs"
+    , "src/lib.rs"
+    , "src/byteorder.rs"
+    ]
+  , "edition": ["2021"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "deps":
+    [ ["@", "byteorder", "", "byteorder"]
+    , ["@", "zerocopy-derive", "", "zerocopy_derive"]
+    ]
+  , "cargo_features": ["simd"]
+  , "stage": ["zerocopy-0.6.6"]
+  , "version": ["0", "6", "6"]
+  , "pkg_name": ["zerocopy"]
+  }
+, "__internal_use_only_features_that_work_on_stable":
+  { "type": ["@", "rules", "cargo", "feature"]
+  , "name": ["__internal_use_only_features_that_work_on_stable"]
+  }
+, "alloc": {"type": ["@", "rules", "cargo", "feature"], "name": ["alloc"]}
+, "simd": {"type": ["@", "rules", "cargo", "feature"], "name": ["simd"]}
+, "simd-nightly":
+  {"type": ["@", "rules", "cargo", "feature"], "name": ["simd-nightly"]}
+}

--- a/etc/deps-rust/TARGETS.zerocopy-derive-0.6.6
+++ b/etc/deps-rust/TARGETS.zerocopy-derive-0.6.6
@@ -1,0 +1,25 @@
+{ "zerocopy_derive":
+  { "type": "export"
+  , "target": "zerocopy_derive-internal"
+  , "flexible_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  }
+, "zerocopy_derive-internal":
+  { "type": ["@", "rules", "rust", "proc-macro"]
+  , "name": ["zerocopy_derive"]
+  , "crate_root": ["src/lib.rs"]
+  , "srcs": ["src/repr.rs", "src/lib.rs", "src/ext.rs"]
+  , "edition": ["2021"]
+  , "arguments_config":
+    ["ARCH", "HOST_ARCH", "TARGET_ARCH", "ENV", "TOOLCHAIN_CONFIG"]
+  , "deps":
+    [ ["@", "proc-macro2", "", "proc_macro2"]
+    , ["@", "quote", "", "quote"]
+    , ["@", "syn", "", "syn"]
+    ]
+  , "cargo_features": []
+  , "stage": ["zerocopy-derive-0.6.6"]
+  , "version": ["0", "6", "6"]
+  , "pkg_name": ["zerocopy-derive"]
+  }
+}

--- a/etc/repos.json
+++ b/etc/repos.json
@@ -23,7 +23,7 @@
       { "type": "git"
       , "repository": "https://github.com/just-buildsystem/rules-cc"
       , "branch": "master"
-      , "commit": "8d715c335756e406aea8a7e3e9e2266f69fbdeb9"
+      , "commit": "0bfac2617f7673c9abb903c155dbd8ddffa26a55"
       , "subdir": "rules"
       }
     }
@@ -32,9 +32,21 @@
       { "type": "git"
       , "repository": "https://github.com/just-buildsystem/rules-rust"
       , "branch": "master"
-      , "commit": "c293d508b10221a7c2ba6b4cb84c38ac328ad4ac"
+      , "commit": "132dadc0f34d3cdf0dc2a63bd7644af6d91d67ec"
       , "subdir": "rules"
       }
+    }
+  , "circle_sampling/byteorder-1.5.0":
+    { "repository":
+      { "type": "archive"
+      , "fetch": "https://crates.io/api/v1/crates/byteorder/1.5.0/download"
+      , "content": "a63d78ae6f940fb4409d32d1fea4e33260b9f2d8"
+      , "subdir": "byteorder-1.5.0"
+      , "distfile": "byteorder-1.5.0.tar.gz"
+      }
+    , "bindings": {"rules": "circle_sampling/rust-rules"}
+    , "target_root": "circle_sampling/external-deps"
+    , "target_file_name": "TARGETS.byteorder-1.5.0"
     }
   , "circle_sampling/cfg-if-1.0.0":
     { "repository":
@@ -83,17 +95,50 @@
     , "target_root": "circle_sampling/external-deps"
     , "target_file_name": "TARGETS.libc-0.2.155"
     }
-  , "circle_sampling/ppv-lite86-0.2.17":
+  , "circle_sampling/ppv-lite86-0.2.18":
     { "repository":
       { "type": "archive"
-      , "fetch": "https://crates.io/api/v1/crates/ppv-lite86/0.2.17/download"
-      , "content": "b142c0fb86f0c3c585c1579a7d671b78441cad27"
-      , "subdir": "ppv-lite86-0.2.17"
-      , "distfile": "ppv-lite86-0.2.17.tar.gz"
+      , "fetch": "https://crates.io/api/v1/crates/ppv-lite86/0.2.18/download"
+      , "content": "e18dc0d7a9280d177f22f7e96338ea4ce49dd9f9"
+      , "subdir": "ppv-lite86-0.2.18"
+      , "distfile": "ppv-lite86-0.2.18.tar.gz"
       }
-    , "bindings": {"rules": "circle_sampling/rust-rules"}
+    , "bindings":
+      { "rules": "circle_sampling/rust-rules"
+      , "zerocopy": "circle_sampling/zerocopy-0.6.6"
+      }
     , "target_root": "circle_sampling/external-deps"
-    , "target_file_name": "TARGETS.ppv-lite86-0.2.17"
+    , "target_file_name": "TARGETS.ppv-lite86-0.2.18"
+    }
+  , "circle_sampling/proc-macro2-1.0.86":
+    { "repository":
+      { "type": "archive"
+      , "fetch": "https://crates.io/api/v1/crates/proc-macro2/1.0.86/download"
+      , "content": "f70bd37da3d9d847323b70945dbbe5669e7cdd99"
+      , "subdir": "proc-macro2-1.0.86"
+      , "distfile": "proc-macro2-1.0.86.tar.gz"
+      }
+    , "bindings":
+      { "rules": "circle_sampling/rust-rules"
+      , "unicode-ident": "circle_sampling/unicode-ident-1.0.12"
+      }
+    , "target_root": "circle_sampling/external-deps"
+    , "target_file_name": "TARGETS.proc-macro2-1.0.86"
+    }
+  , "circle_sampling/quote-1.0.36":
+    { "repository":
+      { "type": "archive"
+      , "fetch": "https://crates.io/api/v1/crates/quote/1.0.36/download"
+      , "content": "c2360e3ce218b963a6b21e2345ee6de406eba2d5"
+      , "subdir": "quote-1.0.36"
+      , "distfile": "quote-1.0.36.tar.gz"
+      }
+    , "bindings":
+      { "rules": "circle_sampling/rust-rules"
+      , "proc-macro2": "circle_sampling/proc-macro2-1.0.86"
+      }
+    , "target_root": "circle_sampling/external-deps"
+    , "target_file_name": "TARGETS.quote-1.0.36"
     }
   , "circle_sampling/rand-0.8.5":
     { "repository":
@@ -122,7 +167,7 @@
       }
     , "bindings":
       { "rules": "circle_sampling/rust-rules"
-      , "ppv-lite86": "circle_sampling/ppv-lite86-0.2.17"
+      , "ppv-lite86": "circle_sampling/ppv-lite86-0.2.18"
       , "rand_core": "circle_sampling/rand_core-0.6.4"
       }
     , "target_root": "circle_sampling/external-deps"
@@ -142,6 +187,68 @@
       }
     , "target_root": "circle_sampling/external-deps"
     , "target_file_name": "TARGETS.rand_core-0.6.4"
+    }
+  , "circle_sampling/syn-2.0.72":
+    { "repository":
+      { "type": "archive"
+      , "fetch": "https://crates.io/api/v1/crates/syn/2.0.72/download"
+      , "content": "b3df52cf09c0c06c69278508851191eaf0e8115f"
+      , "subdir": "syn-2.0.72"
+      , "distfile": "syn-2.0.72.tar.gz"
+      }
+    , "bindings":
+      { "rules": "circle_sampling/rust-rules"
+      , "proc-macro2": "circle_sampling/proc-macro2-1.0.86"
+      , "quote": "circle_sampling/quote-1.0.36"
+      , "unicode-ident": "circle_sampling/unicode-ident-1.0.12"
+      }
+    , "target_root": "circle_sampling/external-deps"
+    , "target_file_name": "TARGETS.syn-2.0.72"
+    }
+  , "circle_sampling/unicode-ident-1.0.12":
+    { "repository":
+      { "type": "archive"
+      , "fetch": "https://crates.io/api/v1/crates/unicode-ident/1.0.12/download"
+      , "content": "5e992e985e30c761a0acb1667cb0037439a59474"
+      , "subdir": "unicode-ident-1.0.12"
+      , "distfile": "unicode-ident-1.0.12.tar.gz"
+      }
+    , "bindings": {"rules": "circle_sampling/rust-rules"}
+    , "target_root": "circle_sampling/external-deps"
+    , "target_file_name": "TARGETS.unicode-ident-1.0.12"
+    }
+  , "circle_sampling/zerocopy-0.6.6":
+    { "repository":
+      { "type": "archive"
+      , "fetch": "https://crates.io/api/v1/crates/zerocopy/0.6.6/download"
+      , "content": "9fbc692df8e1b55561b578a09b8a63a59065dd21"
+      , "subdir": "zerocopy-0.6.6"
+      , "distfile": "zerocopy-0.6.6.tar.gz"
+      }
+    , "bindings":
+      { "rules": "circle_sampling/rust-rules"
+      , "byteorder": "circle_sampling/byteorder-1.5.0"
+      , "zerocopy-derive": "circle_sampling/zerocopy-derive-0.6.6"
+      }
+    , "target_root": "circle_sampling/external-deps"
+    , "target_file_name": "TARGETS.zerocopy-0.6.6"
+    }
+  , "circle_sampling/zerocopy-derive-0.6.6":
+    { "repository":
+      { "type": "archive"
+      , "fetch": "https://crates.io/api/v1/crates/zerocopy-derive/0.6.6/download"
+      , "content": "4e74cbc84d4467710270db9b5d90ce6244ca8b15"
+      , "subdir": "zerocopy-derive-0.6.6"
+      , "distfile": "zerocopy-derive-0.6.6.tar.gz"
+      }
+    , "bindings":
+      { "rules": "circle_sampling/rust-rules"
+      , "proc-macro2": "circle_sampling/proc-macro2-1.0.86"
+      , "quote": "circle_sampling/quote-1.0.36"
+      , "syn": "circle_sampling/syn-2.0.72"
+      }
+    , "target_root": "circle_sampling/external-deps"
+    , "target_file_name": "TARGETS.zerocopy-derive-0.6.6"
     }
   , "circle_sampling/external-deps":
     {"repository": {"type": "file", "path": "etc/deps-rust"}}

--- a/nix-dependencies/dependencies.nix
+++ b/nix-dependencies/dependencies.nix
@@ -40,7 +40,7 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     echo PKG_CONFIG_PATH=$PKG_CONFIG_PATH
     jo TOOLCHAIN_CONFIG=$(jo \
-          CC=$(jo PATH=$(jo -a ${clang}/bin ${coreutils}/bin)) \
+          CC=$(jo PATH=$(jo -a ${clang}/bin ${coreutils}/bin ${busybox}/bin)) \
           PROTO=$(jo PATH=$(jo -a ${protobuf_25}/bin ${grpc}/bin) \
                      PROTOC=${protobuf_25}/bin/protoc \
                      GRPC_PLUGIN=${grpc}/bin/grpc_cpp_plugin \

--- a/src/rust/cargo/circle/Cargo.lock
+++ b/src/rust/cargo/circle/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,9 +40,30 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -69,7 +96,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "zerocopy"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]


### PR DESCRIPTION
... with the latest update of the CC rules, there now is a dependency on sh for CC binaries. Hence extend PATH for CC appropriately.